### PR TITLE
fixup: cover_art path on error pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -9,7 +9,7 @@
   <body>
     <div class="art">
       <a href="/">
-        <img src="./cover_art.png">
+        <img src="/cover_art.png">
       </a>
     </div>
 

--- a/public/422.html
+++ b/public/422.html
@@ -9,7 +9,7 @@
   <body>
     <div class="art">
       <a href="/">
-        <img src="./cover_art.png">
+        <img src="/cover_art.png">
       </a>
     </div>
 

--- a/public/500.html
+++ b/public/500.html
@@ -9,7 +9,7 @@
   <body>
     <div class="art">
       <a href="/">
-        <img src="./cover_art.png">
+        <img src="/cover_art.png">
       </a>
     </div>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38327267/149448451-8760151e-9370-426e-9943-fcc5fd89d244.png)

Fixes ^ (if error occurs on /posts/n/, it looks for /posts/n/cover_art.png, what is 404)