### PR TITLE
Add Github Actions workflow to publish docker image

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Login to docker registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build container image
+        run: docker buildx build -t ghcr.io/${github.repository}:latest -t ghcr.io/${github.repository}:${GITHUB_SHA} .
+      - name: Push image (latest)
+        run: docker push ghcr.io/${github.repository}:latest
+      - name: Push image
+        run: docker push ghcr.io/${github.repository}:${GITHUB_SHA}
+


### PR DESCRIPTION
This adds a Github Actions workflow based on [one I wrote for a different project](https://github.com/NucleoidMC/nucleoid-stats/blob/main/.github/workflows/container.yml) which will publish the Docker container to the Github Container Registry (ghcr.io) using the git commit hash as the version